### PR TITLE
add component method to clear input value

### DIFF
--- a/src/ion-tags-input.ts
+++ b/src/ion-tags-input.ts
@@ -27,7 +27,7 @@ export const CITY_PICKER_VALUE_ACCESSOR: any = {
         <span  *ngFor="let tag of _tags; let $index = index;"
                [class]="'iti-tag iti-tag-color ' + color + ' iti-tag-' + mode">
           {{tag}}
-          <a [hidden]="hideRemove || readonly" 
+          <a [hidden]="hideRemove || readonly"
              class="iti-tag-rm"
              (click)="btnRemoveTag($index)"></a>
        </span>
@@ -195,6 +195,10 @@ export class IonTagsInput implements ControlValueAccessor, OnInit {
     return tags.every( (e: string): boolean => {
       return e !== tagStr
     })
+  }
+
+  clearInputValue() {
+    this._editTag = '';
   }
 
   @HostListener('click', ['$event'])


### PR DESCRIPTION
stumbled upon a usecase where I needed to clear form values, including input value. doing `componentRef._editTag = ''` doesn't look nice, hence this method makes it clear.